### PR TITLE
Add mutable-map support for branch scala28

### DIFF
--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -18,9 +18,11 @@
   </publications>
 
   <dependencies>
-    <dependency org="org.scala-lang" name="scala-compiler" rev="2.7.5" />
-    <dependency org="org.scala-lang" name="scala-library" rev="2.7.5" />
-    <dependency org="net.lag" name="configgy" rev="1.4" />
+    <dependency org="org.scala-lang" name="scala-compiler" rev="2.8.0.Beta1-RC2" />
+	<dependency org="org.scala-lang" name="scala-library" rev="2.8.0.Beta1-RC2" />
+	<dependency org="org.scala-tools.testing" name="specs" rev="1.6.1-2.8.0.Beta1-RC2" conf="test->*">
+		<exclude module="scalatest-1.0.1-for-scala" />
+	</dependency>
 
     <dependency org="org.scala-tools.testing" name="specs" rev="1.4.4" conf="test->*">
       <exclude module="textile-j" />

--- a/project/build.properties
+++ b/project/build.properties
@@ -3,7 +3,7 @@
 project.organization=com.twitter
 project.name=json
 sbt.version=0.7.4
-project.version=2.1.2
+project.version=2.1.3
 def.scala.version=2.7.7
 build.scala.versions=2.8.0
 project.initialize=false

--- a/project/build.properties
+++ b/project/build.properties
@@ -2,8 +2,8 @@
 #Mon Apr 19 22:11:58 PDT 2010
 project.organization=com.twitter
 project.name=json
-sbt.version=0.7.3
-project.version=1.1.2
+sbt.version=0.7.4
+project.version=2.1.2
 def.scala.version=2.7.7
-build.scala.versions=2.7.7
+build.scala.versions=2.8.0
 project.initialize=false

--- a/project/build/ScalaJsonProject.scala
+++ b/project/build/ScalaJsonProject.scala
@@ -3,9 +3,7 @@ import com.twitter.sbt._
 
 
 class ScalaJsonProject(info: ProjectInfo) extends StandardProject(info) {
-  val specs = "org.scala-tools.testing" % "specs" % "1.6.2.1"
-  val vscaladoc = "org.scala-tools" % "vscaladoc" % "1.1-md-3"
-  val configgy = "net.lag" % "configgy" % "1.5.3"
+  val specs = "org.scala-tools.testing" % "specs_2.8.0" % "1.6.5"
 
   Credentials(Path.userHome / ".ivy2" / "credentials", log)
   val publishTo = "nexus" at "http://nexus.scala-tools.org/content/repositories/releases/"

--- a/src/main/scala/com/twitter/json/Json.scala
+++ b/src/main/scala/com/twitter/json/Json.scala
@@ -16,9 +16,8 @@
 
 package com.twitter.json
 
-import net.lag.extensions._
-import scala.collection.Map
-import scala.collection.immutable.EmptyMap
+import extensions._
+import scala.collection.immutable.Map
 import scala.util.parsing.combinator._
 
 
@@ -36,7 +35,7 @@ class JsonException(reason: String) extends Exception(reason)
  * Stolen (awesomely) from the scala book and fixed by making string quotation explicit.
  */
 private class JsonParser extends JavaTokenParsers {
-  def obj: Parser[Map[String, Any]] = "{" ~> repsep(member, ",") <~ "}" ^^ (new EmptyMap ++ _)
+  def obj: Parser[Map[String, Any]] = "{" ~> repsep(member, ",") <~ "}" ^^ (Map.empty ++ _)
 
   def arr: Parser[List[Any]] = "[" ~> repsep(value, ",") <~ "]"
 
@@ -73,8 +72,8 @@ private class JsonParser extends JavaTokenParsers {
  * An explanation of Scala types and their JSON representations.
  *
  * Natively supported scalar types are: Boolean, Int, Long, String.
- * Collections are Seq[T], Map[String, T] where T includes the scalars defined above, or
- * recursive Seq or Map. You are in flavor country.
+ * Collections are Sequence[T], Map[String, T] where T includes the scalars defined above, or
+ * recursive Sequence or Map. You are in flavor country.
  */
 object Json {
   /**
@@ -103,7 +102,7 @@ object Json {
       case null => "null"
       case x: Boolean => x.toString
       case x: Number => x.toString
-      case list: Seq[_] =>
+      case list: Sequence[_] =>
         list.map(build(_).body).mkString("[", ",", "]")
       case map: Map[_, _] =>
         (for ((key, value) <- map.elements) yield {

--- a/src/main/scala/com/twitter/json/Json.scala
+++ b/src/main/scala/com/twitter/json/Json.scala
@@ -47,7 +47,7 @@ private class JsonParser extends JavaTokenParsers {
     case num if num.matches(".*[.eE].*") => BigDecimal(num)
     case num => {
       val rv = num.toLong
-      if (rv >= Math.MIN_INT && rv <= Math.MAX_INT) rv.toInt else rv
+      if (rv >= Int.MinValue && rv <= Int.MaxValue) rv.toInt else rv
     }
   }
 

--- a/src/main/scala/com/twitter/json/Json.scala
+++ b/src/main/scala/com/twitter/json/Json.scala
@@ -113,6 +113,7 @@ object Json {
       case null => "null"
       case x: Boolean => x.toString
       case x: Number => x.toString
+      case array: Array[_] => array.map(build(_).body).mkString("[", ",", "]")
       case list: Sequence[_] =>
         list.map(build(_).body).mkString("[", ",", "]")
       case map: Map[_, _] =>

--- a/src/main/scala/com/twitter/json/Json.scala
+++ b/src/main/scala/com/twitter/json/Json.scala
@@ -18,6 +18,8 @@ package com.twitter.json
 
 import extensions._
 import scala.collection.immutable.Map
+import scala.collection.mutable.Map
+
 import scala.util.parsing.combinator._
 
 
@@ -35,7 +37,7 @@ class JsonException(reason: String) extends Exception(reason)
  * Stolen (awesomely) from the scala book and fixed by making string quotation explicit.
  */
 private class JsonParser extends JavaTokenParsers {
-  def obj: Parser[Map[String, Any]] = "{" ~> repsep(member, ",") <~ "}" ^^ (Map.empty ++ _)
+  def obj: Parser[scala.collection.immutable.Map[String, Any]] = "{" ~> repsep(member, ",") <~ "}" ^^ (scala.collection.immutable.Map.empty ++ _)
 
   def arr: Parser[List[Any]] = "[" ~> repsep(value, ",") <~ "]"
 
@@ -135,10 +137,15 @@ object Json {
       case array: Array[_] => array.map(build(_).body).mkString("[", ",", "]")
       case list: Sequence[_] =>
         list.map(build(_).body).mkString("[", ",", "]")
-      case map: Map[_, _] =>
-        (for ((key, value) <- map.elements) yield {
+      case map: scala.collection.immutable.Map[_, _] =>
+        (for ((key, value) <- map.iterator) yield {
           quote(key.toString) + ":" + build(value).body
         }).mkString("{", ",", "}")
+      case map: scala.collection.mutable.Map[_, _] =>
+        (for ((key, value) <- map.iterator) yield {
+          quote(key.toString) + ":" + build(value).body
+        }).mkString("{", ",", "}")
+      
       case x: JsonSerializable => x.toJson()
       case x =>
         quote(x.toString)

--- a/src/main/scala/com/twitter/json/extensions.scala
+++ b/src/main/scala/com/twitter/json/extensions.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2009 Robey Pointer <robeypointer@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.json
+
+import scala.util.matching.Regex
+
+// These are Robey's extensions from Configgy and when Configgy for 2.8 is done,
+// we'll move back to using it.
+final class ConfiggyString(wrapped: String) {
+  /**
+   * For every section of a string that matches a regular expression, call
+   * a function to determine a replacement (as in python's
+   * `re.sub`). The function will be passed the Matcher object
+   * corresponding to the substring that matches the pattern, and that
+   * substring will be replaced by the function's result.
+   *
+   * For example, this call:
+   *
+   *     "ohio".regexSub("""h.""".r) { m => "n" }
+   *
+   * will return the string `"ono"`.
+   *
+   * The matches are found using `Matcher.find()` and so
+   * will obey all the normal java rules (the matches will not overlap,
+   * etc).
+   *
+   * @param re the regex pattern to replace
+   * @param replace a function that takes Regex.MatchData objects and
+   *     returns a string to substitute
+   * @return the resulting string with replacements made
+   */
+  def regexSub(re: Regex)(replace: (Regex.MatchData => String)): String = {
+    var offset = 0
+    var out = new StringBuilder
+
+    for (m <- re.findAllIn(wrapped).matchData) {
+      if (m.start > offset) {
+        out.append(wrapped.substring(offset, m.start))
+      }
+
+      out.append(replace(m))
+      offset = m.end
+    }
+
+    if (offset < wrapped.length) {
+      out.append(wrapped.substring(offset))
+    }
+    out.toString
+  }
+
+  private val QUOTE_RE = "[\u0000-\u001f\u007f-\uffff\\\\\"]".r
+
+  /**
+   * Quote a string so that unprintable chars (in ASCII) are represented by
+   * C-style backslash expressions. For example, a raw linefeed will be
+   * translated into <code>"\n"</code>. Control codes (anything below 0x20)
+   * and unprintables (anything above 0x7E) are turned into either
+   * <code>"\xHH"</code> or <code>"\\uHHHH"</code> expressions, depending on
+   * their range. Embedded backslashes and double-quotes are also quoted.
+   *
+   * @return a quoted string, suitable for ASCII display
+   */
+  def quoteC(): String = {
+    regexSub(QUOTE_RE) { m =>
+      m.matched.charAt(0) match {
+        case '\r' => "\\r"
+        case '\n' => "\\n"
+        case '\t' => "\\t"
+        case '"' => "\\\""
+        case '\\' => "\\\\"
+        case c =>
+          if (c <= 255) {
+              "\\x%02x" format c.toInt
+          } else {
+              "\\u%04x" format c.toInt
+          }
+      }
+    }
+  }
+
+  // we intentionally don't unquote "\$" here, so it can be used to escape interpolation later.
+  private val UNQUOTE_RE = """\\(u[\dA-Fa-f]{4}|x[\dA-Fa-f]{2}|[/rnt\"\\])""".r
+
+  /**
+   * Unquote an ASCII string that has been quoted in a style like
+   * {@link #quoteC} and convert it into a standard unicode string.
+   * <code>"\\uHHHH"</code> and <code>"\xHH"</code> expressions are unpacked
+   * into unicode characters, as well as <code>"\r"</code>, <code>"\n"<code>,
+   * <code>"\t"</code>, <code>"\\"<code>, and <code>'\"'</code>.
+   *
+   * @return an unquoted unicode string
+   */
+  def unquoteC() = {
+    def unhex(s: String): Char = Integer.valueOf(s, 16).intValue.toChar
+    regexSub(UNQUOTE_RE) { m =>
+      val ch = m.group(1).charAt(0) match {
+        case 'u' | 'x'  => unhex(m.group(1) drop 1)
+        case 'r'        => '\r'
+        case 'n'        => '\n'
+        case 't'        => '\t'
+        case x          => x
+      }
+      ch.toString
+    }
+  }
+
+  /**
+   * Turn a string of hex digits into a byte array. This does the exact
+   * opposite of `Array[Byte]#hexlify`.
+   */
+  def unhexlify(): Array[Byte] = {
+    val buffer = new Array[Byte](wrapped.length / 2)
+    for (i <- 0.until(wrapped.length, 2)) {
+      buffer(i/2) = Integer.parseInt(wrapped.substring(i, i+2), 16).toByte
+    }
+    buffer
+  }
+}
+
+
+final class ConfiggyByteArray(wrapped: Array[Byte]) {
+  /**
+   * Turn an Array[Byte] into a string of hex digits.
+   */
+  def hexlify(): String = {
+    val out = new StringBuffer
+    for (b <- wrapped) {
+      val s = (b.toInt & 0xff).toHexString
+      if (s.length < 2) {
+        out append '0'
+      }
+      out append s
+    }
+    out.toString
+  }
+}
+
+
+object extensions {
+  implicit def stringToConfiggyString(s: String): ConfiggyString = new ConfiggyString(s)
+  implicit def byteArrayToConfiggyByteArray(b: Array[Byte]): ConfiggyByteArray = new ConfiggyByteArray(b)
+}

--- a/src/test/scala/com/twitter/json/JsonSpec.scala
+++ b/src/test/scala/com/twitter/json/JsonSpec.scala
@@ -300,6 +300,36 @@ class JsonSpec extends Specification {
       Json.build(List(0.0, 5.25)).toString mustEqual "[0.0,5.25]"
     }
 
+    "arrays" in {
+      "simple arrays can be encoded" in {
+        Json.build(Array(0, 1)).toString mustEqual "[0,1]"
+      }
+
+      "nested" in {
+        "inside of arrays" in {
+          Json.build(Array(Array(0, 1), 2)).toString mustEqual "[[0,1],2]"
+          Json.build(Array(Array(0, 1), Array(2, 3))).toString mustEqual
+            "[[0,1],[2,3]]"
+        }
+
+        "inside of Lists" in {
+          Json.build(List(Array(0, 1))).toString mustEqual "[[0,1]]"
+          Json.build(List(Array(0, 1), Array(2, 3))).toString mustEqual "[[0,1],[2,3]]"
+        }
+      }
+
+      "maps" in {
+        "can contain arrays" in {
+          Json.build(List(Map("1" -> Array(0, 2)))).toString mustEqual
+          "[{\"1\":[0,2]}]"
+        }
+
+        "can be contained in arrays" in {
+          Json.build(Array(Map("1" -> 2))).toString mustEqual "[{\"1\":2}]"
+        }
+      }
+    }
+
     "build JsonSerializable objects" in {
       val obj = new JsonSerializable {
         def toJson() = "\"abracadabra\""

--- a/src/test/scala/com/twitter/json/JsonSpec.scala
+++ b/src/test/scala/com/twitter/json/JsonSpec.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.json
 
-<import extensions._
+import extensions._
 import org.specs._
 import scala.collection.immutable
 

--- a/src/test/scala/com/twitter/json/JsonSpec.scala
+++ b/src/test/scala/com/twitter/json/JsonSpec.scala
@@ -150,6 +150,10 @@ class JsonSpec extends Specification {
       "empty map" in {
         Json.build(Map()).toString mustEqual "{}"
       }
+      
+      "mutable map" in {
+        Json.build(scala.collection.mutable.HashMap()).toString mustEqual "{}"
+      }
 
       "empty list" in {
         Json.build(Map("nil" -> Nil)).toString mustEqual "{\"nil\":[]}"

--- a/src/test/scala/com/twitter/json/JsonSpec.scala
+++ b/src/test/scala/com/twitter/json/JsonSpec.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.json
 
-import net.lag.extensions._
+import extensions._
 import org.specs._
 import scala.collection.immutable
 

--- a/src/test/scala/com/twitter/json/JsonSpec.scala
+++ b/src/test/scala/com/twitter/json/JsonSpec.scala
@@ -21,7 +21,7 @@ import org.specs._
 import scala.collection.immutable
 
 
-object JsonSpec extends Specification {
+class JsonSpec extends Specification {
   "Json" should {
     "quote strings" in {
       "unicode within latin-1" in {
@@ -297,7 +297,7 @@ object JsonSpec extends Specification {
 
     "build numbers" in {
       Json.build(List(42, 23L, 1.67, BigDecimal("1.67456352431287348917591342E+50"))).toString mustEqual "[42,23,1.67,1.67456352431287348917591342E+50]";
-      Json.build(Array(0.0, 5.25)).toString mustEqual "[0.0,5.25]"
+      Json.build(List(0.0, 5.25)).toString mustEqual "[0.0,5.25]"
     }
 
     "build JsonSerializable objects" in {

--- a/src/test/scala/com/twitter/json/TestRunner.scala
+++ b/src/test/scala/com/twitter/json/TestRunner.scala
@@ -16,7 +16,6 @@
 
 package com.twitter.json
 
-import net.lag.configgy.Configgy
 import org.specs.runner.SpecsFileRunner
 
 object TestRunner extends SpecsFileRunner("src/test/scala/**/*.scala", ".*",


### PR DESCRIPTION
Currently, the scala-json won't process mutable map correctly in Scala28 branch. Maybe you want to add few lines to support them just like my branch.
