### PR TITLE
treats UTF-8 as is

### DIFF
--- a/src/main/scala/com/twitter/json/Json.scala
+++ b/src/main/scala/com/twitter/json/Json.scala
@@ -117,7 +117,6 @@ object Json {
       case c if c > 0xffff =>
         val chars = Character.toChars(c)
         "\\u%04x\\u%04x".format(chars(0).toInt, chars(1).toInt)
-      case c if c > 0x7e => "\\u%04x".format(c.toInt)
       case c => c.toChar
     }
   }

--- a/src/test/scala/com/twitter/json/JsonSpec.scala
+++ b/src/test/scala/com/twitter/json/JsonSpec.scala
@@ -25,11 +25,11 @@ class JsonSpec extends Specification {
   "Json" should {
     "quote strings" in {
       "unicode within latin-1" in {
-        Json.quote("hello\n\u009f") mustEqual "\"hello\\n\\u009f\""
+        Json.quote("hello\n\u009f") mustEqual "\"hello\\n\u009f\""
       }
 
-      "unicode outside of latin-1 (the word Tokyo)" in {
-        Json.quote("\u6771\u4eac") mustEqual "\"\\u6771\\u4eac\""
+      "UTF-8 as is (the word Tokyo)" in {
+        Json.quote("\u6771\u4eac") mustEqual "\"\u6771\u4eac\""
       }
 
       "string containing unicode outside of the BMP (using UTF-16 surrogate pairs)" in {


### PR DESCRIPTION
We multi-bytes users want to treat UTF-8 as is like Yajl(Ruby). 
FYI, Yajl(ruby) doesn't quote UTF-8 strings.

This patch quotes not UCS-2(UTF-8) but only UCS-4(UTF-16). 
Thanks
